### PR TITLE
RDKB-62988 [GitHub Coverity] Enable Coverity Scan for cable-modem-agent using Native Build Integration

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,33 @@
+name: Build Cable Modem Agent component in Native Environment
+
+on:
+  push:
+    branches: [ main, 'sprint/**', 'release/**', develop ]
+  pull_request:
+    branches: [ main, 'sprint/**', 'release/**', topic/RDK*, develop ]
+
+jobs:
+  build-cable-modem-agent-on-pr:
+    name: Build Cable Modem Agent component in github rdkcentral
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rdkcentral/docker-rdk-ci:latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: native build
+        run: |
+          # Trust the workspace
+          git config --global --add safe.directory '*'
+          # Pull the latest changes for the native build system
+          git submodule update --init --recursive --remote
+          # Build and install dependencies
+          chmod +x build_tools_workflows/cov_docker_script/setup_dependencies.sh
+          ./build_tools_workflows/cov_docker_script/setup_dependencies.sh ./cov_docker_script/component_config.json
+          # Build component
+          chmod +x build_tools_workflows/cov_docker_script/build_native.sh
+          ./build_tools_workflows/cov_docker_script/build_native.sh ./cov_docker_script/component_config.json "$(pwd)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "build_tools_workflows"]
+	path = build_tools_workflows
+	url = https://github.com/rdkcentral/build_tools_workflows
+	branch = develop

--- a/cov_docker_script/README.md
+++ b/cov_docker_script/README.md
@@ -1,0 +1,3 @@
+# 🔧 Coverity Native Build System for RDK-B Components
+
+The documentation and source for the RDK-B native build system has been centralized in [rdkcentral/build_tools_workflows](https://github.com/rdkcentral/build_tools_workflows/blob/develop/cov_docker_script/README.md)

--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -1,0 +1,143 @@
+{
+  "_comment": "Component Build Configuration for Coverity/Native Builds",
+  "_version": "2.0",
+  "_description": "Defines dependencies and build settings for the native component",
+
+  "dependencies": {
+    "_comment": "External repositories needed by this component",
+    "repos": [
+      {
+        "name": "safec",
+        "repo": "https://github.com/rurban/safeclib.git",
+        "branch": "master",
+        "header_paths": [
+          { "source": "include", "destination": "$HOME/usr/include/rdkb" }
+        ],
+        "build": {
+          "type": "autotools"
+        }
+      },
+      {
+        "name": "Utopia",
+        "repo": "https://github.com/rdkcentral/utopia.git",
+        "branch": "develop",
+        "header_paths": [
+          { "source": "source/include/sysevent", "destination": "$HOME/usr/include/rdkb/sysevent" },
+          { "source": "source/include/syscfg", "destination": "$HOME/usr/include/rdkb/syscfg" },
+          { "source": "source/include", "destination": "$HOME/usr/include/rdkb/utctx" },
+          { "source": "source/include", "destination": "$HOME/usr/include/rdkb" },
+          { "source": "source/utapi/lib", "destination": "$HOME/usr/include/rdkb/utapi" },
+          { "source": "source/include/ulog", "destination": "$HOME/usr/include/rdkb/ulog" },
+          { "source": "source/util/utils", "destination": "$HOME/usr/include/rdkb" },
+          { "source": "source/sysevent/lib", "destination": "$HOME/usr/include/rdkb/sysevent" },
+          { "source": "source/util/print_uptime", "destination": "$HOME/usr/include/rdkb" }
+        ],
+        "build": {
+          "type": "script",
+	  "script": "build_tools_workflows/cov_docker_script/common_external_build.sh"
+        }
+      },
+      {
+        "name": "Utopia-headers",
+        "repo": "https://github.com/rdkcentral/utopia.git",
+        "branch": "main",
+        "header_paths": [
+          { "source": "source/include/sysevent", "destination": "$HOME/usr/include/rdkb/sysevent" },
+          { "source": "source/include/syscfg", "destination": "$HOME/usr/include/rdkb/syscfg" },
+          { "source": "source/include/utctx", "destination": "$HOME/usr/include/rdkb/utctx" },
+          { "source": "source/include", "destination": "$HOME/usr/include/rdkb" },
+          { "source": "source/utapi/lib", "destination": "$HOME/usr/include/rdkb/utapi" },
+          { "source": "source/include/ulog", "destination": "$HOME/usr/include/rdkb/ulog" },
+          { "source": "source/util/utils", "destination": "$HOME/usr/include/rdkb" },
+          { "source": "source/sysevent/lib", "destination": "$HOME/usr/include/rdkb/sysevent" },
+          { "source": "source/util/print_uptime", "destination": "$HOME/usr/include/rdkb" }
+        ]
+      },
+      {
+        "name": "rdkb-halif-vlan",
+        "repo": "https://github.com/rdkcentral/rdkb-halif-vlan.git",
+        "branch": "main",
+        "header_paths": [
+          { "source": "include", "destination": "$HOME/usr/include" }
+        ]
+      },
+      {
+        "name": "rdkb-halif-wifi",
+        "repo": "https://github.com/rdkcentral/rdkb-halif-wifi.git",
+        "branch": "develop",
+        "header_paths": [
+          { "source": "include", "destination": "$HOME/usr/include" }
+        ]
+      },
+      {
+        "name": "rdkb-halif-cm",
+        "repo": "https://github.com/rdkcentral/rdkb-halif-cm.git",
+        "branch": "main",
+        "header_paths": [
+          { "source": "include", "destination": "$HOME/usr/include" }
+        ]
+      },
+      {
+        "name": "miscellaneous-broadband",
+        "repo": "https://github.com/rdkcentral/miscellaneous-broadband.git",
+        "branch": "main",
+        "header_paths": [
+          { "source": "source/TimeConv", "destination": "$HOME/usr/include/rdkb" },
+	  { "source": "source/FwDownloadChk", "destination": "$HOME/usr/include/rdkb" }
+        ],
+        "build": {
+          "type": "commands",
+	      "commands": [
+			"mkdir -p $HOME/usr/lib",
+			"gcc -shared -fPIC source/TimeConv/time_conversion.c -o $HOME/usr/lib/libtime_conversion.so -I$HOME/usr/include/rdkb -I./source/TimeConv -D_GNU_SOURCE -w",
+			"gcc -shared -fPIC source/FwDownloadChk/fw_download_check.c -o $HOME/usr/lib/libfw_download_chk.so -I$HOME/usr/include/rdkb -I./source/FwDownloadChk -D_GNU_SOURCE -w"
+			]
+        }
+      },
+      {
+        "name": "hal-cm-generic",
+        "repo": "https://code.rdkcentral.com/r/rdkb/components/opensource/ccsp/hal.git",
+        "branch": "rdk-next",
+        "repo_dir": "hal-cm-generic/source/cm",
+        "include_path": "$HOME/usr/include/rdkb/",
+        "lib_output_path": "$HOME/usr/local/lib",
+        "build": {
+        "type": "commands",
+        "commands": [
+            "echo \"${PWD}\"",
+            "cd source/cm",
+            "autoreconf -i",
+            "./configure",
+            "make CFLAGS=\"-Os -pipe -g -feliminate-unused-debug-types -I${HOME}/usr/include/rdkb -I${HOME}/build/rdkb-halif-cm/include\" LDFLAGS=\"-Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed\""
+         ]
+        }
+      }
+    ]
+  },
+
+  "native_component": {
+    "_comment": "Configuration for the main component being built",
+    "name": "cable-modem-agent",
+    "include_path": "$HOME/usr/include/rdkb",
+    "lib_output_path": "$HOME/usr/local/lib",
+    "pre_build_commands": [
+      {
+        "description": "Generate dm_pack_datamodel.c from XML",
+        "command": "python3 $HOME/usr/include/rdkb/dm_pack_code_gen.py config-arm/TR181-CM.XML source/CMAgentSsp/dm_pack_datamodel.c"
+      }
+    ],
+    "header_sources": [
+      { "source": "config.h", "destination": "$HOME/usr/include/rdkb" },
+      { "source": "source/CMAgentSsp", "destination": "$HOME/usr/include/rdkb" },
+      { "source": "source/Custom", "destination": "$HOME/usr/include/rdkb" },
+      { "source": "source/TR-181/include", "destination": "$HOME/usr/include/rdkb" },
+      { "source": "source/TR-181/middle_layer_src", "destination": "$HOME/usr/include/rdkb" },
+      { "source": "source/test/CcspCMAgentDmlTest", "destination": "$HOME/usr/include/rdkb" }
+    ],
+    "build": {
+    "type": "autotools",
+    "build_dir": "build",
+    "configure_options_file": "cov_docker_script/configure_options.conf"
+    }
+  }
+}

--- a/cov_docker_script/configure_options.conf
+++ b/cov_docker_script/configure_options.conf
@@ -1,0 +1,124 @@
+# Cable Modem Agent Configure Options
+# This file contains autotools configure options for the cable-modem-agent component
+# Each section can be edited independently for better maintainability
+
+# ============================================================================
+# CPPFLAGS - Preprocessor flags (includes and defines)
+# ============================================================================
+[CPPFLAGS]
+# Autotools configuration
+-DHAVE_CONFIG_H
+
+# Include paths
+-I$HOME/usr/include
+-I$HOME/usr/include/rdkb/
+-I/usr/include/dbus-1.0
+-I/usr/lib/x86_64-linux-gnu/dbus-1.0/include
+
+# Core system defines
+-DSAFEC_DUMMY_API
+-D_COSA_HAL_
+-U_COSA_SIM_
+-DCONFIG_SYSTEM_MOCA
+
+# ANSC framework defines
+-D_ANSC_LINUX
+-D_ANSC_USER
+-D_ANSC_LITTLE_ENDIAN_
+-D_ANSC_USE_OPENSSL_
+-D_ANSC_AES_USED_
+-D_NO_ANSC_ZLIB_
+-U_ANSC_IPV6_COMPATIBLE_
+
+# CCSP/Component defines
+-D_CCSP_CWMP_TCP_CONNREQ_HANDLER
+-D_DSLH_STUN_
+-D_NO_PKI_KB5_SUPPORT
+-D_BBHM_SSE_FILE_IO
+-DCCSP_SUPPORT_ENABLED
+
+# Product/Platform defines
+-D_COSA_INTEL_USG_ARM_
+-D_COSA_FOR_COMCAST_
+-D_COSA_BCM_ARM_
+-D_XB6_PRODUCT_REQ_
+-D_XB7_PRODUCT_REQ_
+-D_XB8_PRODUCT_REQ_
+
+# Vendor/Customer configuration
+-DCONFIG_VENDOR_CUSTOMER_COMCAST
+-DCONFIG_CISCO_HOTSPOT
+
+# Security and debugging
+-DENABLE_SA_KEY
+-D_NO_EXECINFO_H_
+-D_DEBUG
+-DINCLUDE_BREAKPAD
+
+# System features
+-DFEATURE_SUPPORT_RDKLOG
+-DFEATURE_SUPPORT_SYSLOG
+-DBUILD_WEB
+-DUSE_NOTIFY_COMPONENT
+-DNTPD_ENABLE
+-DUTC_ENABLE
+-DUTC_ENABLE_ATOM
+-DXDNS_ENABLE
+
+# Cable Modem Agent specific
+-DENABLE_LLD_SUPPORT
+
+# Network features
+-DENABLE_ETH_WAN
+-DEROUTER_DHCP_OPTION_MTA
+-DETH_4_PORTS
+-D_2_5G_ETHERNET_SUPPORT_
+-D_MACSEC_SUPPORT_
+-D_BRIDGE_UTILS_BIN_
+-DAUTOWAN_ENABLE
+-DENABLE_WANMODECHANGE_NOREBOOT
+-DFEATURE_RDKB_WAN_MANAGER
+-DFEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE
+-DWAN_MANAGER_UNIFICATION_ENABLED
+-DWAN_FAILOVER_SUPPORTED
+-DGATEWAY_FAILOVER_SUPPORTED
+
+# Advanced features
+-D_PSM_TRANS_RDK_TRIGG_
+-D_CM_HIGHSPLIT_SUPPORTED_
+-DFEATURE_RDKB_INTER_DEVICE_MANAGER
+-DFEATURE_SUPPORT_MAPT_NAT46
+-DMAPT_UNIFICATION_ENABLED
+-DSPEED_BOOST_SUPPORTED
+-DAMENITIES_NETWORK_ENABLED
+
+# Test/Development
+-DCOLUMBO_HWTEST
+
+# Build system
+-DRBUS_BUILD_FLAG_ENABLE
+
+# Standard defines
+-D_GNU_SOURCE
+-D__USE_XOPEN
+
+# ============================================================================
+# CFLAGS - Compiler flags
+# ============================================================================
+[CFLAGS]
+-ffunction-sections
+-fdata-sections
+-fomit-frame-pointer
+-fno-strict-aliasing
+
+# ============================================================================
+# LDFLAGS - Linker flags
+# ============================================================================
+[LDFLAGS]
+-L$HOME/usr/local/lib/
+-L$HOME/usr/lib 
+-Wl,-rpath-link,$HOME/usr/lib
+-Wl,--allow-shlib-undefined
+-Wl,--unresolved-symbols=ignore-all
+-ldbus-1
+-lccsp_common


### PR DESCRIPTION
Reason for change: Native build and Github Action Workflow Changes for Enabling Coverity Scan for github cable-modem-agent
Test Procedure: verify able-modem-agent dependency and build native build and using Github workflow
Risks: Low
Priority: P1

Signed-off-by: Deepak.M <deepak_m@comcast.com>